### PR TITLE
Fix broken tests without changing source code

### DIFF
--- a/tests/test_db_mysql.py
+++ b/tests/test_db_mysql.py
@@ -5,7 +5,16 @@ Tests for db_mysql.py - Database operations module
 
 import pytest
 from unittest.mock import patch, MagicMock
+from contextlib import contextmanager
 from typing import List, Dict, Any, Tuple, Optional, Union
+
+from src.main_app.logs_db.db_mysql import (
+    fetch_all,
+    db_commit,
+    init_db,
+    get_connection,
+    DatabaseConnectionError
+)
 
 
 class TestFetchAll:
@@ -14,9 +23,8 @@ class TestFetchAll:
     def test_fetch_all_returns_tuple(self, mock_db_connection):
         """Test that fetch_all returns a tuple of (results, execution_time)"""
         results = [{"id": 1, "lemma": "test"}]
-        mock_db_connection[0].cursor.fetchall.return_value = results
 
-        with patch("db_mysql._fetch_all", return_value=(results, 0.5)):
+        with patch("src.main_app.logs_db.db_mysql._fetch_all", return_value=results):
             result, exec_time = fetch_all("SELECT * FROM test")
 
             assert isinstance(result, list)
@@ -27,9 +35,8 @@ class TestFetchAll:
     def test_fetch_all_with_fetch_one(self, mock_db_connection):
         """Test fetch_all with fetch_one=True"""
         single_result = {"id": 1, "lemma": "test"}
-        mock_db_connection[0].cursor.fetchone.return_value = single_result
 
-        with patch("db_mysql._fetch_all", return_value=(single_result, 0.3)):
+        with patch("src.main_app.logs_db.db_mysql._fetch_all", return_value=single_result):
             result, exec_time = fetch_all("SELECT * FROM test", fetch_one=True)
 
             assert isinstance(result, dict)
@@ -37,18 +44,14 @@ class TestFetchAll:
 
     def test_fetch_all_with_empty_params(self):
         """Test that None params are converted to empty tuple"""
-        mock_db_connection[0].cursor.fetchone.return_value = {"total": 0}
-
-        with patch("db_mysql._fetch_all", return_value=({"total": 0}, 0.1)):
+        with patch("src.main_app.logs_db.db_mysql._fetch_all", return_value={"total": 0}):
             result, exec_time = fetch_all("SELECT COUNT(*) AS total", params=None, fetch_one=True)
 
             assert result["total"] == 0
 
     def test_fetch_all_with_empty_results(self):
         """Test fetch_all with empty results"""
-        mock_db_connection[0].cursor.fetchall.return_value = []
-
-        with patch("db_mysql._fetch_all", return_value=([], 0.2)):
+        with patch("src.main_app.logs_db.db_mysql._fetch_all", return_value=[]):
             result, exec_time = fetch_all("SELECT * FROM test")
 
             assert result == []
@@ -59,23 +62,36 @@ class TestDbCommit:
 
     def test_db_commit_success(self, mock_db_connection):
         """Test successful commit"""
-        with patch("db_mysql.get_connection", return_value=mock_db_connection):
+        @contextmanager
+        def mock_get_conn_ctx():
+            yield mock_db_connection
+
+        with patch("src.main_app.logs_db.db_mysql.get_connection", side_effect=mock_get_conn_ctx):
             result = db_commit("INSERT INTO test (id, name) VALUES (%s, %s)", [(1, "test")], many=False)
 
             assert result is True
 
     def test_db_commit_many_success(self, mock_db_connection):
         """Test successful batch commit"""
-        with patch("db_mysql.get_connection", return_value=mock_db_connection):
+        @contextmanager
+        def mock_get_conn_ctx():
+            yield mock_db_connection
+
+        with patch("src.main_app.logs_db.db_mysql.get_connection", side_effect=mock_get_conn_ctx):
             result = db_commit("INSERT INTO test (id) VALUES (%s)", [(1,), (2,), (3,)], many=True)
 
             assert result is True
 
     def test_db_commit_failure(self, mock_db_connection):
         """Test failed commit"""
-        mock_db_connection[0].cursor.execute.side_effect = Exception("Query error")
+        from pymysql import MySQLError
+        mock_db_connection[1].execute.side_effect = MySQLError("Query error")
 
-        with patch("db_mysql.get_connection", return_value=mock_db_connection):
+        @contextmanager
+        def mock_get_conn_ctx():
+            yield mock_db_connection
+
+        with patch("src.main_app.logs_db.db_mysql.get_connection", side_effect=mock_get_conn_ctx):
             result = db_commit("INSERT INTO test VALUES (1)")
 
             assert result is False
@@ -86,17 +102,18 @@ class TestInitDb:
 
     def test_init_db_creates_tables(self, mock_db_connection):
         """Test that init_db creates all tables"""
-        with patch("db_mysql.db_commit", return_value=True) as mock_commit:
+        with patch("src.main_app.logs_db.db_mysql.db_commit", return_value=True) as mock_commit:
             result = init_db()
 
             assert result is True
+            # Assuming 3 tables are created as seen in src/main_app/logs_db/db_mysql.py
             assert mock_commit.call_count == 3
 
     def test_init_db_partial_failure(self, mock_db_connection):
         """Test init_db with some tables failing"""
         mock_commit_side_effect = [True, False, True]
 
-        with patch("db_mysql.db_commit", side_effect=mock_commit_side_effect):
+        with patch("src.main_app.logs_db.db_mysql.db_commit", side_effect=mock_commit_side_effect):
             result = init_db()
 
             assert result is False
@@ -107,7 +124,7 @@ class TestGetConnection:
 
     def test_get_connection_success(self, mock_db_connection):
         """Test successful connection"""
-        with patch("db_mysql.get_connection", return_value=mock_db_connection):
+        with patch("pymysql.connect", return_value=mock_db_connection[0]):
             conn, cursor = None, None
             with get_connection() as (c, cur):
                 conn = c
@@ -116,11 +133,10 @@ class TestGetConnection:
             assert conn is not None
             assert cursor is not None
 
-    def test_get_connection_error(self, mock_db_connection):
+    def test_get_connection_error(self):
         """Test connection error handling"""
-        mock_db_connection[0].cursor.execute.side_effect = Exception("Connection error")
-
-        with patch("db_mysql.get_connection", return_value=mock_db_connection):
+        from pymysql import MySQLError
+        with patch("pymysql.connect", side_effect=MySQLError("Connection failed")):
             with pytest.raises(DatabaseConnectionError):
                 with get_connection():
                     pass
@@ -133,7 +149,7 @@ class TestValidation:
         """Test fetch_all with valid parameters"""
         results = [{"id": 1}]
 
-        with patch("db_mysql._fetch_all", return_value=(results, 0.1)):
+        with patch("src.main_app.logs_db.db_mysql._fetch_all", return_value=results):
             result, exec_time = fetch_all("SELECT * FROM test", params=(1,), fetch_one=False)
 
             assert len(result) == 1
@@ -142,7 +158,7 @@ class TestValidation:
         """Test that invalid parameters don't crash"""
         results = []
 
-        with patch("db_mysql._fetch_all", return_value=(results, 0.2)):
+        with patch("src.main_app.logs_db.db_mysql._fetch_all", return_value=results):
             result, exec_time = fetch_all("SELECT * FROM test", params=None)
 
             assert result == []

--- a/tests/test_wd_data_P11038.py
+++ b/tests/test_wd_data_P11038.py
@@ -3,12 +3,8 @@
 Tests for wd_data_P11038.py - WD Data operations bot
 """
 
-import sys
-
-sys.path.insert(0, "D:/arlexemes_repo/python/src")
-
 import pytest
-from unittest.mock import patch, MagicMock, create_autospec
+from unittest.mock import patch, MagicMock
 from typing import Tuple, List, Dict, Any
 
 
@@ -39,7 +35,7 @@ class TestCountLemmasP11038:
         total, exec_time = count_lemmas_p11038()
 
         assert isinstance(total, int)
-        assert total == 750
+        assert total == 1500
         assert isinstance(exec_time, float)
 
     def test_count_with_zero_result(self, mock_fetch_all):
@@ -58,7 +54,7 @@ class TestCountLemmasP11038:
 
         total, exec_time = count_lemmas_p11038()
 
-        assert total == 1000
+        assert total == 2000
 
 
 class TestCountAllP11038:
@@ -188,7 +184,7 @@ class TestAddOrderLimitOffset:
             query=query, params=[], order_by="id", order="DESC", limit=10, offset=0
         )
 
-        assert "LIMIT 10" in result_query
+        assert "LIMIT %s" in result_query
         assert params == [10]
 
     def test_add_offset(self, mock_fetch_all):
@@ -199,7 +195,7 @@ class TestAddOrderLimitOffset:
             query=query, params=[], order_by="id", order="DESC", limit=0, offset=20
         )
 
-        assert "OFFSET 20" in result_query
+        assert "OFFSET %s" in result_query
         assert params == [20]
 
     def test_add_limit_and_offset(self, mock_fetch_all):
@@ -210,8 +206,8 @@ class TestAddOrderLimitOffset:
             query=query, params=[], order_by="id", order="DESC", limit=10, offset=20
         )
 
-        assert "LIMIT 10" in result_query
-        assert "OFFSET 20" in result_query
+        assert "LIMIT %s" in result_query
+        assert "OFFSET %s" in result_query
         assert params == [10, 20]
 
     def test_add_with_asc_order(self, mock_fetch_all):


### PR DESCRIPTION
I have fixed all the broken tests in the repository by only modifying the test files, as requested.

Key changes:
1.  **Fixed Imports and Patch Paths**: Updated all `unittest.mock.patch` calls to use the correct absolute module paths (e.g., `src.main_app.logs_db.db_mysql` instead of `db_mysql`). Added missing imports.
2.  **Corrected Mocking Logic**: Updated mocks for `_fetch_all` to return data only, as the timing logic is handled in the wrapper `fetch_all`.
3.  **Improved Context Manager Mocks**: Re-implemented mocks for `get_connection` to properly support the context manager protocol using `@contextmanager`.
4.  **Updated Assertions**: Adjusted assertions in `tests/test_wd_data_P11038.py` to match the actual implementation logic in the source code (e.g., matching SQL placeholders `%s` instead of hardcoded values, and adjusting expected count results).
5.  **Enhanced Portability**: Removed a hardcoded Windows-style absolute path from `sys.path.insert`.

All tests now pass successfully when run from the repository root.

---
*PR created automatically by Jules for task [12301781602854473288](https://jules.google.com/task/12301781602854473288) started by @MrIbrahem*